### PR TITLE
Match ZeroShotClassification name in Embeddings end code

### DIFF
--- a/exercises/Embeddings/End/Program.cs
+++ b/exercises/Embeddings/End/Program.cs
@@ -4,5 +4,5 @@
 
 await new SentenceSimilarity().RunAsync();
 //await new ManualSemanticSearch().RunAsync();
-//await new ZeroShotClassifier().RunAsync();
+//await new ZeroShotClassification().RunAsync();
 //await new FaissSemanticSearch().RunAsync();


### PR DESCRIPTION
This pull request includes a small change to the `exercises/Embeddings/End/Program.cs` file. The change updates a commented-out method name to reflect the actual class name.

* [`exercises/Embeddings/End/Program.cs`](diffhunk://#diff-e06b256aacc984172124195ab2ae069cfc20a90107d75a3aa3c1255d88126f6cL7-R7): Changed `ZeroShotClassifier` to `ZeroShotClassification` in a commented-out line.